### PR TITLE
Modify AGP 9 upgrade skill

### DIFF
--- a/build/agp/agp-9-upgrade/SKILL.md
+++ b/build/agp/agp-9-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agp-9-upgrade
 description: Upgrades, or migrates, an Android project to use Android Gradle Plugin
-  (AGP) version 9
+  (AGP) version 9. Do not use this skill for migrating Kotlin Multiplatform (KMP) projects.
 license: Complete terms in LICENSE.txt
 metadata:
   author: Google LLC
@@ -23,41 +23,54 @@ breaking, in AGP 9 compared to AGP 8.
 
 If the user requests to update or migrate to AGP 9, first check the AGP version
 used in the project. If it is lower than 9, stop and ask the user to run the AGP
-Upgrade Assistant in Android Studio, and confirm when done.
+Upgrade Assistant in Android Studio to update to the latest stable version of
+AGP, and confirm when done. The user may also request that this requirement be
+skipped; if this is the case, you should update the version of AGP to the latest
+stable version as part of the AGP 9 migration. See the
+[AGP 9 migration guide](references/android/build/releases/agp-9-0-0-release-notes.md)
+for how to do this.
 
 Each version of AGP has its own set of compatibilities with other tools, such as
 Gradle, JDK, and Kotlin. The release notes for each of these versions will
 include a **Compatibility** table indicating the minimum versions for these
 tools.
 
+Do not use this skill for KMP projects, as they are unsupported.
+
 ## Steps
 
 If AGP is already at 9 or higher, then do the following:
 
-### Step 1: Migrate to built-in Kotlin.
+### Step 1: Update dependencies
+
+If KSP (`com.google.devtools.ksp`) is used in the project, ensure it is on
+version 2.3.6 or higher.
+
+If Hilt is used in the project, ensure it is on version 2.59.2 or higher.
+
+### Step 2: Migrate to built-in Kotlin.
 
 See [the guide](references/android/build/migrate-to-built-in-kotlin.md) for detailed information.
 
-### Step 2. Migrate to the new AGP DSL.
+### Step 3. Migrate to the new AGP DSL.
 
 See [the guide](references/android/build/releases/agp-9-0-0-release-notes.md) for detailed information.
 
 See also [gradle-recipes](references/recipes.md) for examples on how to migrate old code to code
 that is compatible with AGP 9 and the new DSL.
 
-### Step 3. Migrate kapt to KSP or legacy-kapt
+### Step 4. Migrate kapt to KSP or legacy-kapt
 
-If KSP (`com.google.devtools.ksp`) is used in the project, ensure it is on
-version 2.3.6 or higher.
+If KSP (`com.google.devtools.ksp`) or kapt (`org.jetbrains.kotlin.kapt`) are
+used in the project, [KSP, kapt, and legacy-kapt](references/ksp-kapt.md)
+for detailed migration steps.
 
-See [KSP, kapt, and legacy-kapt](references/ksp-kapt.md) for detailed information.
-
-### Step 4. BuildConfig
+### Step 5. BuildConfig
 
 If any Android module contains custom BuildConfig fields, see [BuildConfig](references/buildconfig.md)
 for detailed information.
 
-### Step 5. Update gradle.properties
+### Step 6. Update gradle.properties
 
 After the migration, check gradle.properties. Remove the following flags:
 

--- a/build/agp/agp-9-upgrade/references/recipes.md
+++ b/build/agp/agp-9-upgrade/references/recipes.md
@@ -2,6 +2,13 @@ When migrating to AGP's new DSL, any Gradle code (plugins or logic in build
 scripts) that relied on the old DSL will stop working. Such code must be
 migrated.
 
+## Guidelines
+
+- **DO NOT** search the web for examples of how to do this. Use the
+  **gradle-recipes** repository examples **only**.
+- **DO NOT** use AGP internals in migrated code.
+- **DO** use only public APIs in migrated code.
+
 In some cases, there is a one-to-one replacement for the old code. Some examples
 are in [the AGP 9.0.0 release notes](https://developer.android.com/build/releases/agp-9-0-0-release-notes).
 
@@ -54,6 +61,3 @@ However, with AGP 9 and the new DSL, `applicationVariants` is no longer
 available. You must instead react to artifact creation using the
 `androidComponents.onVariants` API. A complete example of this is available in
 the **gradle-recipes** repository in the `listenToArtifacts` recipe.
-
-**DO NOT** search the web for examples of how to do this. Use the
-**gradle-recipes** repository examples **only**.


### PR DESCRIPTION
Minor changes to the skill, including stating that it's for non-KMP projects.