### PR TITLE
Update android-cli skill

### DIFF
--- a/devtools/android-cli/SKILL.md
+++ b/devtools/android-cli/SKILL.md
@@ -68,7 +68,7 @@ Capture an image of the current screen of a connected Android device and output 
 
 ## Managing skills
 
-Manage antigravity agent skills for Android using the `android skills` command.
+Manage agent skills for Android using the `android skills` command.
 
 ## Inspecting UI Layouts
 

--- a/devtools/android-cli/references/interact.md
+++ b/devtools/android-cli/references/interact.md
@@ -74,7 +74,7 @@ To tap on this button, you would execute `adb shell input tap 152 23`. This taps
   "center": "[250,400]"
 }
 ```
-To scroll down on this list, you would execute `adb shell input swipe 250 400 600 500`. This swipes from the center to the bottom over 500ms.
+To scroll down on this list, you would execute `adb shell input swipe 250 400 250 200 500`. This swipes from the center to the top over 500ms.
 
 # Android Interaction Rules
 1. Always ensure text input fields have `"focused"` in their `"state"` list before entering text


### PR DESCRIPTION
- Remove brand name "antigravity" when referring to agent skills.
- Fix parameters in the adb shell input swipe command example to include all required coordinates and duration.