### PR TITLE
feat(play-policy-insights): Add support for .NET MAUI apps

### DIFF
--- a/play/play-policy-insights/resources/scanner_config.json
+++ b/play/play-policy-insights/resources/scanner_config.json
@@ -17,7 +17,11 @@
                 "getPositionStream",
                 "LocationAccuracy.high",
                 "react-native-geolocation-service",
-                "Expo.Location"
+                "Expo.Location",
+                "Geolocation.GetLocationAsync",
+                "GeolocationRequest",
+                "GeolocationAccuracy",
+                "Microsoft.Maui.Devices.Sensors"
             ],
             "APPROX_LOCATION": [
                 "ACCESS_COARSE_LOCATION",
@@ -27,7 +31,9 @@
                 "ip_location",
                 "ip_country",
                 "LocationAccuracy.low",
-                "LocationAccuracy.balanced"
+                "LocationAccuracy.balanced",
+                "GeolocationAccuracy.Low",
+                "GeolocationAccuracy.Lowest"
             ],
             "USER_ACCOUNT": [
                 "AccountManager",
@@ -53,7 +59,12 @@
                 "Auth0",
                 "@react-native-firebase/auth",
                 "react-native-google-signin",
-                "react-native-app-auth"
+                "react-native-app-auth",
+                "WebAuthenticator",
+                "IPublicClientApplication",
+                "AcquireTokenInteractive",
+                "SecureStorage.SetAsync",
+                "Microsoft.Identity.Client"
             ],
             "ACCOUNT_DELETION": [
                 "deleteAccount",
@@ -71,12 +82,12 @@
                 "firstName",
                 "lastName",
                 "display_name",
-		"full_name",
+                "full_name",
                 "fullName",
                 "real_name",
                 "realName",
                 "family_name",
-		"familyName",
+                "familyName",
                 "given_name",
                 "contact_name",
                 "profile_name",
@@ -101,7 +112,9 @@
                 "email_id",
                 "primary_email",
                 "keyboardType=\"email-address\"",
-                "TextInputType.emailAddress"
+                "TextInputType.emailAddress",
+                "Email.ComposeAsync",
+                "EmailMessage"
             ],
             "ADDRESS": [
                 "textPostalAddress",
@@ -126,7 +139,9 @@
                 "telephone",
                 "phone_id",
                 "textContentType=\"telephoneNumber\"",
-                "TextInputType.phone"
+                "TextInputType.phone",
+                "PhoneDialer.Open",
+                "PhoneDialer.Default"
             ],
             "RACE_ETHNICITY": [
                 "race",
@@ -257,7 +272,9 @@
                 "SEND_SMS",
                 "READ_CALL_LOG",
                 "WRITE_CALL_LOG",
-                "SmsRetriever"
+                "SmsRetriever",
+                "Sms.ComposeAsync",
+                "SmsMessage"
             ],
             "OTHER_MESSAGES": [
                 "chat_message",
@@ -296,7 +313,9 @@
                 "launchCamera",
                 "react-native-image-picker",
                 "expo-image-picker",
-                "wechat_assets_picker"
+                "wechat_assets_picker",
+                "MediaPicker.PickPhotoAsync",
+                "MediaPicker.CapturePhotoAsync"
             ],
             "VIDEOS": [
                 "READ_MEDIA_VIDEO",
@@ -312,7 +331,9 @@
                 "pickVideo",
                 "react-native-vision-camera",
                 "CameraRoll",
-                "expo-image-picker"
+                "expo-image-picker",
+                "MediaPicker.PickVideoAsync",
+                "MediaPicker.CaptureVideoAsync"
             ],
             "AUDIO": [
                 "AudioRecord",
@@ -338,7 +359,10 @@
                 "flutter_sound",
                 "FlutterSoundRecorder",
                 "react-native-audio-recorder-player",
-                "expo-av"
+                "expo-av",
+                "Permissions.Microphone",
+                "SpeechToText",
+                "AudioRecorder"
             ],
             "MUSIC": [
                 "MediaPlayer",
@@ -419,7 +443,9 @@
                 "react-native-mmkv",
                 "Sembast",
                 "RxDB",
-                "Realm"
+                "Realm",
+                "FilePicker.PickAsync",
+                "FilePicker.PickMultipleAsync"
             ],
             "CALENDAR": [
                 "READ_CALENDAR",
@@ -428,7 +454,9 @@
                 "device_calendar",
                 "retrieveCalendars",
                 "react-native-calendar-events",
-                "RNCalendarEvents"
+                "RNCalendarEvents",
+                "Permissions.CalendarRead",
+                "Permissions.CalendarWrite"
             ],
             "CONTACTS": [
                 "READ_CONTACTS",
@@ -439,7 +467,10 @@
                 "flutter_contacts",
                 "FlutterContacts",
                 "react-native-contacts",
-                "Contacts.getAll"
+                "Contacts.getAll",
+                "Contacts.PickContactAsync",
+                "Contacts.GetAllAsync",
+                "Microsoft.Maui.ApplicationModel.Communication.Contacts"
             ],
             "APP_INTERACTIONS": [
                 "logEvent",
@@ -502,7 +533,9 @@
                 "recordFlutterError",
                 "recordError",
                 "SentryFlutter",
-                "crashlytics()"
+                "crashlytics()",
+                "Microsoft.AppCenter.Crashes",
+                "SentrySdk"
             ],
             "PERFORMANCE_DIAGNOSTICS": [
                 "ActivityManager",
@@ -565,7 +598,9 @@
                 "DeviceInfo",
                 "getUniqueId",
                 "getAndroidId",
-                "getAdvertisingId"
+                "getAdvertisingId",
+                "DeviceInfo.Current",
+                "Microsoft.Maui.Devices.DeviceInfo"
             ],
             "OTHER_ACTIONS": [
                 "gameplay",
@@ -583,7 +618,12 @@
                 "http.get",
                 "http.post",
                 "Dio",
-                "HttpClient"
+                "HttpClient",
+                "HttpRequestMessage",
+                "GetStringAsync",
+                "RestSharp",
+                "Refit",
+                "Flurl"
             ]
         },
         "exact_alarm": {
@@ -783,7 +823,9 @@
         "web",
         "macos",
         "windows",
-        "linux"
+        "linux",
+        "bin",
+        "obj"
     ],
     "supported_extensions": [
         ".java",
@@ -794,6 +836,8 @@
         ".tsx",
         ".dart",
         ".cs",
-        ".vue"
+        ".vue",
+        ".csproj",
+        ".xaml"
     ]
 }

--- a/play/play-policy-insights/scripts/generate_report.py
+++ b/play/play-policy-insights/scripts/generate_report.py
@@ -44,7 +44,7 @@ def run_scraper(package_name, output_dir):
     # Save to temp for consistency with existing report logic if needed
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, "play_store_declaration.json")
-    with open(out_path, "w") as f:
+    with open(out_path, "w", encoding="utf-8") as f:
       json.dump(result, f, indent=4, sort_keys=True)
 
     return result
@@ -239,7 +239,7 @@ def load_json(file_path):
   """Loads JSON from a file if it exists."""
   if os.path.exists(file_path):
     try:
-      with open(file_path, "r") as f:
+      with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
         return json.load(f)
     except Exception as e:
       print(f"Warning: Failed to load {file_path}: {e}", file=sys.stderr)
@@ -688,7 +688,7 @@ def main():
   if not play_store_info and package_name:
     play_store_info = run_scraper(package_name, temp_dir)
     # Cache it for report reuse
-    with open(play_store_info_path, "w") as f:
+    with open(play_store_info_path, "w", encoding="utf-8") as f:
       json.dump(play_store_info, f, indent=4, sort_keys=True)
 
   report_data = aggregate_findings(temp_dir, taxonomy)
@@ -701,7 +701,7 @@ def main():
     sys.exit(1)
 
   try:
-    with open(template_path, "r") as f:
+    with open(template_path, "r", encoding="utf-8") as f:
       content = f.read()
   except Exception as e:
     print(f"Error reading template: {e}", file=sys.stderr)
@@ -832,11 +832,11 @@ def main():
 
   content = render_template(content, template_context)
 
-  with open(output_path, "w") as f:
+  with open(output_path, "w", encoding="utf-8") as f:
     f.write(content)
 
   json_output_path = output_path.replace(".md", ".json")
-  with open(json_output_path, "w") as f:
+  with open(json_output_path, "w", encoding="utf-8") as f:
     json.dump(
         {
             "metadata": {

--- a/play/play-policy-insights/scripts/orchestrator.py
+++ b/play/play-policy-insights/scripts/orchestrator.py
@@ -58,6 +58,21 @@ FRAMEWORK_DEFAULTS = {
     "flutter.ndkVersion": "25.1.8937393",
 }
 
+# .NET MAUI / .NET for Android express the target SDK through the target framework
+# moniker rather than a manifest or Gradle file. An explicit platform level wins
+# (net9.0-android35.0 -> 35); an unqualified moniker (net9.0-android) resolves to
+# the highest API the installed workload supports, which is fixed per .NET release.
+DOTNET_ANDROID_TARGET_SDK = {
+    "8.0": 34,
+    "9.0": 35,
+    "10.0": 36,
+}
+
+# net10.0-android, net10.0-android36.0, net8.0-android34.0 ...
+DOTNET_TFM_PATTERN = re.compile(
+    r"net(\d+\.\d+)-android(\d+)?(?:\.\d+)?", re.IGNORECASE
+)
+
 # Patterns for diverse assignment styles (Groovy & Kotlin DSL)
 # 1. Standard: targetSdkVersion = 35, ext.targetSdkVersion = 35, etc.
 # 2. Delegated: val targetSdkVersion by extra(35)
@@ -402,7 +417,7 @@ def determine_primary_identity(
   if not primary_id or not primary_sdk:
     for m_file in manifest_files:
       try:
-        with open(m_file, "r", encoding="utf-8") as f:
+        with open(m_file, "r", encoding="utf-8-sig") as f:
           content = f.read()
           details = extract_manifest_details(content)
           if not primary_id:
@@ -439,7 +454,87 @@ def determine_primary_identity(
       except Exception:  # pylint: disable=broad-exception-caught
         pass
 
+    # Check for .NET MAUI / .NET for Android (*.csproj)
+    if not primary_id or not primary_sdk:
+      dotnet_id, dotnet_sdk, dotnet_label = extract_dotnet_android_details(
+          app_dir
+      )
+      primary_id = primary_id or dotnet_id
+      primary_sdk = primary_sdk or dotnet_sdk
+      primary_label = primary_label or dotnet_label
+
   return primary_id, primary_sdk, primary_label
+
+
+def _msbuild_property(content, tag):
+  """Reads a single MSBuild property value out of a project file."""
+  match = re.search(
+      rf"<{tag}[^>]*>([^<]+)</{tag}>", content, re.IGNORECASE
+  )
+  return match.group(1).strip() if match else None
+
+
+def extract_dotnet_android_details(app_dir):
+  """Finds the .NET MAUI / .NET for Android project and reads its identity.
+
+  A .NET for Android app has no Gradle files, and its AndroidManifest.xml carries
+  neither the package name nor uses-sdk -- both are MSBuild properties merged into
+  the manifest at build time. Without this the audit sees an app with no id and no
+  target SDK and reports nothing, which reads as a clean bill of health.
+
+  Args:
+    app_dir: Absolute path to the directory containing the app's code.
+
+  Returns:
+    A tuple of (application_id, target_sdk, application_title). Any element is
+    None when it could not be determined.
+  """
+  app_id = None
+  target_sdk = None
+  label = None
+
+  config = scanner.get_scanner_config()
+  ignored_dirs = set(config.get("ignored_directories", []))
+
+  candidates = []
+  for root, dirs, files in os.walk(app_dir):
+    dirs[:] = [d for d in dirs if d not in ignored_dirs]
+    for f in files:
+      if f.lower().endswith(".csproj"):
+        candidates.append(os.path.join(root, f))
+
+  for csproj in sorted(candidates):
+    try:
+      with open(csproj, "r", encoding="utf-8", errors="ignore") as f:
+        content = f.read()
+    except Exception:  # pylint: disable=broad-exception-caught
+      continue
+
+    content = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
+
+    tfm_match = DOTNET_TFM_PATTERN.search(content)
+    if not tfm_match:
+      # Not an Android head project (class libraries, test projects).
+      continue
+
+    app_id = app_id or _msbuild_property(content, "ApplicationId")
+    label = label or _msbuild_property(content, "ApplicationTitle")
+
+    if target_sdk is None:
+      # Explicit override wins, then the moniker's platform level, then the
+      # workload default for that .NET release.
+      explicit = _msbuild_property(content, "AndroidTargetSdkVersion")
+      if explicit and explicit.isdigit():
+        target_sdk = int(explicit)
+      elif tfm_match.group(2):
+        target_sdk = int(tfm_match.group(2))
+      else:
+        target_sdk = DOTNET_ANDROID_TARGET_SDK.get(tfm_match.group(1))
+
+    if app_id and target_sdk and label:
+      break
+
+  return app_id, target_sdk, label
 
 
 def extract_manifest_details(xml_content):
@@ -453,8 +548,12 @@ def extract_manifest_details(xml_content):
   }
 
   try:
-    # Handle XML with namespaces
-    root = ET.fromstring(xml_content)
+    # Strip a UTF-8 BOM before parsing. Visual Studio writes one into
+    # AndroidManifest.xml by default, and ElementTree rejects it as an invalid
+    # token at line 1. The permission scan below is regex-based and survives, so
+    # the failure is silent: the manifest still yields permissions while quietly
+    # losing the package name, target SDK and app label.
+    root = ET.fromstring(xml_content.lstrip("\ufeff"))
     ns = {"android": "http://schemas.android.com/apk/res/android"}
 
     details["package_name"] = root.get("package")
@@ -731,7 +830,7 @@ def run_aggregation(temp_dir, repo_root):
   for w_file in worker_files:
     basename = os.path.basename(w_file)
     try:
-      with open(w_file, "r") as f:
+      with open(w_file, "r", encoding="utf-8") as f:
         w_data = json.load(f)
       findings_list = w_data.get("findings", [])
       if isinstance(findings_list, list):
@@ -750,7 +849,7 @@ def run_aggregation(temp_dir, repo_root):
 
   # Save the master list of all findings
   aggregated_path = os.path.join(temp_dir, "aggregated_findings.json")
-  with open(aggregated_path, "w") as f:
+  with open(aggregated_path, "w", encoding="utf-8") as f:
     json.dump({"findings": all_findings}, f, indent=4)
 
   # Filter findings that need Critic evaluation: skip only SUGGESTION findings
@@ -772,7 +871,7 @@ def run_aggregation(temp_dir, repo_root):
   critic_template_path = os.path.join(repo_root, "resources", "critic.md")
   critic_template = ""
   if os.path.exists(critic_template_path):
-    with open(critic_template_path, "r") as f:
+    with open(critic_template_path, "r", encoding="utf-8") as f:
       critic_template = f.read()
 
   common_mandates_path = os.path.join(
@@ -780,7 +879,7 @@ def run_aggregation(temp_dir, repo_root):
   )
   common_mandates = ""
   if os.path.exists(common_mandates_path):
-    with open(common_mandates_path, "r") as f:
+    with open(common_mandates_path, "r", encoding="utf-8") as f:
       common_mandates = f.read()
 
   full_template = critic_template + "\n\n" + common_mandates
@@ -790,7 +889,7 @@ def run_aggregation(temp_dir, repo_root):
   base_context = {}
   if os.path.exists(manifest_path):
     try:
-      with open(manifest_path, "r") as f:
+      with open(manifest_path, "r", encoding="utf-8", errors="ignore") as f:
         m_details = json.load(f)
         base_context["APP_DIR"] = m_details.get("app_dir")
     except Exception:  # pylint: disable=broad-exception-caught
@@ -806,7 +905,7 @@ def run_aggregation(temp_dir, repo_root):
     # Create input_critic_<idx>.json
     chunk_dict = {f["finding_id"]: f for f in chunk}
     chunk_input_path = os.path.join(temp_dir, f"input_critic_{idx}.json")
-    with open(chunk_input_path, "w") as f:
+    with open(chunk_input_path, "w", encoding="utf-8") as f:
       json.dump(chunk_dict, f, indent=4)
 
     # Render prompt_critic_<idx>.md
@@ -815,7 +914,7 @@ def run_aggregation(temp_dir, repo_root):
 
     final_prompt = render_template(full_template, chunk_context)
     chunk_prompt_path = os.path.join(temp_dir, f"prompt_critic_{idx}.md")
-    with open(chunk_prompt_path, "w") as f:
+    with open(chunk_prompt_path, "w", encoding="utf-8") as f:
       f.write(final_prompt)
 
   return len(chunks)
@@ -1066,7 +1165,10 @@ def main():
 
         if os.path.exists(manifest_path):
           try:
-            with open(manifest_path, "r") as f:
+            # Manifests are UTF-8. Without an explicit encoding this falls back
+            # to the platform default, which on Windows is the locale codepage:
+            # the file arrives mojibake and every downstream parse fails.
+            with open(manifest_path, "r", encoding="utf-8-sig") as f:
               content = f.read()
               if not manifest_content:
                 manifest_content = content
@@ -1139,7 +1241,11 @@ def main():
         if "store_url" not in play_store_info:
           play_store_info["store_url"] = f"file://{local_info_path}"
 
-        with open(os.path.join(temp_dir, "play_store_info.json"), "w") as out_f:
+        with open(
+            os.path.join(temp_dir, "play_store_info.json"),
+            "w",
+            encoding="utf-8",
+        ) as out_f:
           json.dump(play_store_info, out_f, indent=4)
       print(
           f"Ingested local Play Store info from {local_info_path}",

--- a/play/play-policy-insights/scripts/play_store_scraper.py
+++ b/play/play-policy-insights/scripts/play_store_scraper.py
@@ -165,7 +165,7 @@ def load_taxonomy():
   repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
   policy_path = os.path.join(repo_root, "resources", "policies.json")
   try:
-    with open(policy_path, "r") as f:
+    with open(policy_path, "r", encoding="utf-8", errors="ignore") as f:
       data = json.load(f)
       taxonomy = data.get("data_safety_section", {}).get("taxonomy", {})
       return {

--- a/play/play-policy-insights/scripts/scanner.py
+++ b/play/play-policy-insights/scripts/scanner.py
@@ -184,9 +184,11 @@ def _scan_single_file(file_path, all_signal_categories, target_dir):
         if any(kw in url.lower() for kw in policy_url_keywords):
           found_urls.append(url)
 
-      # Cleanup comments based on file type
+      # Cleanup comments based on file type. .csproj and .xaml are XML documents
+      # despite their extensions, so they use XML comment syntax rather than the
+      # C-style stripping applied to source files.
       file_path_lower = file_path.lower()
-      if file_path_lower.endswith(".xml"):
+      if file_path_lower.endswith((".xml", ".csproj", ".xaml")):
         content = XML_COMMENT_PATTERN.sub("", content)
       elif file_path_lower.endswith(supported_exts):
         content = COMMENT_STRIP_PATTERN.sub(


### PR DESCRIPTION
### Summary
Adds .NET MAUI application scanning and analysis support to the `play-policy-insights` skill, along with portability fixes and explicit UTF-8 file handling.

### Key Changes
- **.NET MAUI Support:** Extended scanner configuration and orchestrator logic to identify and analyze .NET MAUI project structures and dependencies.
- **Portability & Encodings:** Added explicit encoding parameters (`utf-8`) across file `open()` operations.
- **Report Generation:** Updated report generator and scanner scripts to handle MAUI-specific artifacts.

### Contributor Credit
- Contributed by @darthmolen
- Authored by: @darthmolen
- Coordinated & submitted by: @<your-github-username>

### Testing
- Verified scanner configuration with sample MAUI project manifests.
- Verified UTF-8 encoding handling across updated Python scripts.